### PR TITLE
chore: add missing .PHONY annotation to Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 $(eval WSL_GATEWAY = $(shell sh -c "ifconfig eth0 | grep 'inet ' | sed -e 's/  */:/g' | cut -d: -f3"))
 export WSL_GATEWAY
 
+.PHONY: up-scrap start-ab start-h2 start-aj
+
 up-scrap:
 	docker-compose -f docker-compose.yaml up -d
 


### PR DESCRIPTION
## Summary
- Added `.PHONY` declaration for all Makefile targets (`up-scrap`, `start-ab`, `start-h2`, `start-aj`) to prevent conflicts with files of the same name

## Test plan
- [ ] Verify `make` targets still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)