### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,7 +115,7 @@ boss/
 ├── docker-compose.ab.yaml       # Apache Benchmark testing
 ├── docker-compose.aj.yaml       # Apache JMeter testing  
 ├── docker-compose.h2.yaml       # h2load HTTP/2 testing
-├── apache-benchmark/            # Apache Benchmark container (Alpine 3.16.1)
+├── apache-benchmark/            # Apache Benchmark container (Alpine 3.16.9)
 │   ├── Dockerfile
 │   └── entrypoint.sh
 ├── apache-jmeter/               # JMeter container and configs
@@ -126,7 +126,7 @@ boss/
 │   ├── open-api.Dockerfile      # OpenAPI-to-JMX converter (openapi-generator-cli v6.0.1)
 │   ├── open-api.entrypoint.sh
 │   └── result_describer         # Python CSV analyzer script
-├── nghttp2/                     # h2load container (Alpine 3.16.1)
+├── nghttp2/                     # h2load container (Alpine 3.16.9)
 │   ├── Dockerfile
 │   └── entrypoint.sh
 ├── grafana/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `CLAUDE.md` with build commands, key conventions, and utility script references
+
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to correct Alpine base image version from 3.16.1 to 3.16.9
+
 ## [0.1.1] - 2026-04-23
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Boss is a Docker-based performance testing toolkit. It orchestrates load testing with Apache Benchmark, JMeter, and h2load alongside a Prometheus + Grafana monitoring stack. All services run as Docker containers via Compose.
+
+## Build and Run Commands
+
+Every docker-compose command requires `WSL_GATEWAY` to be set first:
+
+```bash
+export WSL_GATEWAY=$(ifconfig eth0 | grep 'inet ' | sed -e 's/  */:/g' | cut -d: -f3)
+```
+
+Makefile targets (use `docker-compose` v1 syntax internally):
+
+| Target | Compose File | Purpose |
+|---|---|---|
+| `up-scrap` | `docker-compose.yaml` | Grafana + Prometheus stack |
+| `start-ab` | `docker-compose.ab.yaml` | Apache Benchmark stress test |
+| `start-aj` | `docker-compose.aj.yaml` | JMeter load test |
+| `start-h2` | `docker-compose.h2.yaml` | h2load HTTP/2 stress test |
+
+Alternatively, use `docker compose` (v2) directly:
+
+```bash
+docker compose -f docker-compose.yaml up -d
+```
+
+## Key Conventions
+
+- The Makefile uses `docker-compose` (v1). Systems with only v2 should call `docker compose` directly.
+- Test targets and environment variables are configured per compose file, not via external config. Edit the relevant `docker-compose.*.yaml` to set `TARGET_URL`, `REQUESTS_TOTAL`, etc.
+- `prometheus/config.yaml` ships with placeholder targets -- it must be edited before Prometheus will scrape real metrics.
+- JMeter's OpenAPI-to-JMX pipeline: the `open-api` service downloads an OpenAPI spec and converts it to `.jmx` files in `apache-jmeter/input/`, then the `jmeter` service executes them and writes results to `apache-jmeter/output/`.
+
+## Utility Scripts
+
+```bash
+python3 scripts/test_endpoints.py         # endpoint validation (edit test_cases in script)
+python3 apache-jmeter/result_describer    # JMeter CSV result analysis (edit CSV path in script)
+```
+
+Both require `pandas` and `requests`.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.