### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,8 +101,7 @@ Boss is a comprehensive performance testing and monitoring toolkit that uses Doc
 - **WSL Networking**: Requires dynamic IP detection for proper container communication
   - **CRITICAL**: Always export WSL_GATEWAY before running Docker commands
 
-- **No CI/CD Workflows**: The `.github/workflows/` directory contains only a `.gitkeep` placeholder — no automated pipelines are configured yet
-  - **NOTE**: All validation must be done manually as described in the sections above
+- **CI/CD**: `.github/workflows/release.yaml` runs on pushes to `main` and delegates to the reusable workflow at `rios0rios0/pipelines`. No per-PR CI exists yet — all testing is manual as described above
 
 ## Common Tasks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to document the `release.yaml` CI workflow (was incorrectly listed as having no CI/CD)
+
 ## [0.2.0] - 2026-04-28
 
 ### Added


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.