### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,7 +134,7 @@ boss/
 ├── prometheus/
 │   └── config.yaml              # Prometheus scrape configuration
 └── scripts/
-    └── test_endpoints.py        # Endpoint validation script (requires: pandas, requests)
+    └── test_endpoints.py        # Endpoint validation script (requires: requests)
 ```
 
 ### Key Configuration Files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to correct the Python dependency attribution (`test_endpoints.py` needs only `requests`, `result_describer` needs only `pandas`)
+
 ## [0.2.1] - 2026-05-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,4 +43,4 @@ python3 scripts/test_endpoints.py         # endpoint validation (edit test_cases
 python3 apache-jmeter/result_describer    # JMeter CSV result analysis (edit CSV path in script)
 ```
 
-Both require `pandas` and `requests`.
+`test_endpoints.py` requires `requests`; `result_describer` requires `pandas`.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.